### PR TITLE
Fix occasionally failing API authorization

### DIFF
--- a/lib/turbosms/client.rb
+++ b/lib/turbosms/client.rb
@@ -2,30 +2,31 @@ require 'savon'
 
 module TurboSMS
   class << self
-    
+
     private
-    
+
     def client
       @client ||= Savon.client(wsdl: default_options[:wsdl], log: false)
     end
-    
+
     def authorized?
       !@cookies.nil?
     end
-    
+
     def auth_message
       keys = [:login, :password]
       default_options.select{|key,_| keys.include? key}
     end
-    
+
     def authorize
       response  = client.call(:auth, message: auth_message)
       result    = response.body[:auth_response][:auth_result]
       @cookies = response.http.cookies if (result.length == 27) # Ridiculous # Вы успешно авторизировались
       raise AuthError, result unless authorized?
     end
-    
+
     def authorised_call(method_name, args = {})
+      authorize
       response_key  = "#{method_name}_response".to_sym
       result_key    = "#{method_name}_result".to_sym
       response = client.call(method_name, args.merge(cookies: @cookies))
@@ -34,6 +35,6 @@ module TurboSMS
       @cookies = nil if !result.instance_of?(Array) and result.length == 20 # Ridiculous # Вы не авторизированы
       result
     end
-    
+
   end
 end


### PR DESCRIPTION
If you have a long running process doing the SMS stuff, you will end up with occasional "TurboSMS::SendingSMSError: Вы не авторизированы" happening from time to time, because the cookie got expired, or the server deleted the session associated with it. Creating new session on every call may be a bit slower (I'm not sure it is), but at least your messages will be delivered.

Maybe there's a better way, but I got that going for me, which is nice.

Also my editor couldn't resist fixing whitespaces in the file, sorry for that. The only important part is line 29.
